### PR TITLE
Downgrade to be able to add to plugin BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>5.3</version>
+    <version>4.88</version>
     <relativePath />
   </parent>
 
@@ -61,7 +61,7 @@
     <revision>2.29.21</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.baseline>2.452</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <autoVersionSubmodules>true</autoVersionSubmodules>
     <spotless.check.skip>false</spotless.check.skip>


### PR DESCRIPTION
With version=5.3 and jenkins.baseline=2.479, we aren't able to add these plugins to bom.

By downgrading to version=4.88 and jenkins.baseline=2.452, we will be able to.

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue